### PR TITLE
Removed unexpected closing tags

### DIFF
--- a/braze-templates/2-braze-dashboard-simple-modal/index.html
+++ b/braze-templates/2-braze-dashboard-simple-modal/index.html
@@ -348,8 +348,6 @@
                             fill="#A8B3B8" />
                     </svg>
                 </button>
-                </svg>
-                </button>
                 <h1 class="modal__title">This is where the modal title goes</h1>
                 <h2 class="modal__sub-title">Sub head maybe here that is not too long</h2>
                 <p class="modal__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor


### PR DESCRIPTION
Integrating the custom in-app message I noticed two unexpected closing tags:

```html
</svg>
</button>
```