### PR TITLE
Fixing CSS for squished checkbox

### DIFF
--- a/braze-templates/4-sms-capture-modal/index.html
+++ b/braze-templates/4-sms-capture-modal/index.html
@@ -160,6 +160,7 @@
             border: 1px solid #A8B3B8;
             border-radius: 3px;
             margin-right: 20px;
+            flex: none;
         }
 
         .modal__tick {


### PR DESCRIPTION
Fix for the issue raised in this slack thread:
https://brazetechnology.slack.com/archives/C03A4QR4U2G/p1660311631394679

Current Behavior:
The checkbox gets squished when the label is past a certain character length. It's expected that this label be long as it needs to contain the terms and conditions / verbiage shown to the user before they consent to receive SMS.

Expected Behavior:
Checkbox doesn't get squished.

I'm not an HTML expert by any means, but this appears to fix the issue.

@nickrobin @davidbielik - saw that you are both contributors on this repo but recognize it's not actively maintained by any team. Not sure how kosher this is but would be good to fix. 